### PR TITLE
Add missing closing curly brace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Once a component is decorated, you can use all the power of [Radium](http://stac
 
 ```javascript
 render() {
-  return <p style={{ ':hover': { color: '#2196F3' }}>Hover me</p>;
+  return <p style={{ ':hover': { color: '#2196F3' } }}>Hover me</p>;
 }
 ```
 


### PR DESCRIPTION
I spotted a small typo as I was trying out your examples.

Thank you for putting this starter repo together.
